### PR TITLE
feat(projects): add Frontier Terminal as featured project

### DIFF
--- a/components/sections/projects.tsx
+++ b/components/sections/projects.tsx
@@ -158,6 +158,78 @@ function ProjectCard({ name, description, techStack, url }: ProjectCardProps) {
   return cardContent;
 }
 
+interface FeaturedProjectCardProps {
+  name: string;
+  description: string;
+  techStack: string[];
+  url?: string;
+}
+
+function FeaturedBadge() {
+  return (
+    <motion.span
+      className="absolute top-4 right-4 px-3 py-1.5 text-xs font-bold uppercase tracking-wider rounded-full"
+      style={{
+        background: `linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(100, 150, 255, 0.2))`,
+        border: "1px solid rgba(0, 255, 255, 0.4)",
+        color: "var(--neon-cyan)",
+        boxShadow: `0 0 10px rgba(0, 255, 255, 0.3), 0 0 20px rgba(0, 255, 255, 0.1)`,
+        backdropFilter: "blur(4px)",
+      }}
+      animate={{ scale: [1, 1.02, 1] }}
+      transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+    >
+      Featured
+    </motion.span>
+  );
+}
+
+function FeaturedProjectCard({ name, description, techStack, url }: FeaturedProjectCardProps) {
+  const cardContent = (
+    <HolographicCard className="relative glitch-on-hover">
+      <FeaturedBadge />
+
+      {/* Project Name */}
+      <GlitchWrapper intensity="subtle" trigger="hover">
+        <h3
+          className="text-2xl sm:text-3xl font-bold mb-6 cursor-pointer"
+          style={{ color: "var(--neon-electric)" }}
+        >
+          {name}
+        </h3>
+      </GlitchWrapper>
+
+      {/* Two-column interior on md+ */}
+      <div className="flex flex-col md:flex-row gap-6 md:gap-10">
+        {/* Description */}
+        <p
+          className="text-sm sm:text-base leading-relaxed md:flex-1"
+          style={{ color: "rgba(255, 255, 255, 0.75)" }}
+        >
+          {description}
+        </p>
+
+        {/* Tech Stack */}
+        <div className="flex flex-wrap gap-2 content-start md:w-64 md:shrink-0">
+          {techStack.map((tech, index) => (
+            <TechBadge key={tech} tech={tech} index={index} />
+          ))}
+        </div>
+      </div>
+    </HolographicCard>
+  );
+
+  if (url) {
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer" className="block">
+        {cardContent}
+      </a>
+    );
+  }
+
+  return cardContent;
+}
+
 function Projects() {
   const sectionRef = React.useRef<HTMLElement>(null);
   const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
@@ -188,21 +260,38 @@ function Projects() {
           </GlitchWrapper>
         </motion.div>
 
-        {/* Projects Grid - 2 columns on desktop, stacked on mobile */}
+        {/* Row 1: MacroCrafter + TheWay — 2-column grid */}
         <motion.div
           variants={itemVariants}
-          className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8"
+          className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mb-6 md:mb-8"
         >
-          {projects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              name={project.name}
-              description={project.description}
-              techStack={project.techStack}
-              url={project.url}
-            />
-          ))}
+          {projects
+            .filter((p) => p.id !== "frontier-terminal")
+            .map((project) => (
+              <ProjectCard
+                key={project.id}
+                name={project.name}
+                description={project.description}
+                techStack={project.techStack}
+                url={project.url}
+              />
+            ))}
         </motion.div>
+
+        {/* Row 2: Frontier Terminal — featured full-width card */}
+        {projects.find((p) => p.id === "frontier-terminal") && (() => {
+          const ft = projects.find((p) => p.id === "frontier-terminal")!;
+          return (
+            <motion.div variants={itemVariants}>
+              <FeaturedProjectCard
+                name={ft.name}
+                description={ft.description}
+                techStack={ft.techStack}
+                url={ft.url}
+              />
+            </motion.div>
+          );
+        })()}
       </motion.div>
     </section>
   );

--- a/lib/resume-data.ts
+++ b/lib/resume-data.ts
@@ -93,6 +93,26 @@ export const projects: Project[] = [
     techStack: ["React Native", "Expo Router", "NativeWind", "Legend State", "NestJS", "Supabase (PostgreSQL, Edge Functions, Realtime, Auth)", "Letta AI", "Google Gemini API", "TypeScript"],
     featured: true,
   },
+  {
+    id: "frontier-terminal",
+    name: "Frontier Terminal",
+    url: "https://frontier-terminal.com",
+    description:
+      "AI-native financial intelligence platform built as a Bloomberg Terminal alternative for retail investors. Features real-time market data, AI-powered research reports, personalized daily briefings, multi-channel alert delivery (Telegram, Discord, email, webhooks), a conversational AI analyst with persistent portfolio memory, and a multi-agent backend architecture for continuous intelligence delivery.",
+    techStack: [
+      "Next.js 16",
+      "React 19",
+      "TypeScript",
+      "Supabase (PostgreSQL, Edge Functions, Realtime)",
+      "Vercel AI SDK",
+      "Tailwind CSS v4",
+      "shadcn/ui",
+      "Stripe",
+      "Fly.io",
+      "GitHub Actions",
+    ],
+    featured: true,
+  },
 ];
 
 // ============================================================================
@@ -126,6 +146,7 @@ export const jobs: Job[] = [
     description: [
       "MacroCrafter: AI-powered macro generation SaaS for World of Warcraft and Final Fantasy XIV gaming communities. Full-stack application featuring real-time streaming chat with multiple LLM providers (xAI Grok, OpenAI), three-tier Stripe subscription system with webhook lifecycle management, and secure multi-tenant architecture using Supabase Auth with PostgreSQL Row-Level Security.",
       "TheWay: AI-powered mobile app guiding users through personalized spiritual journeys with daily devotionals, Orthodox calendar integration, and an intelligent conversational assistant. Features include a full 76-book Orthodox Bible reader with annotations, AI-generated liturgical imagery, gamified progression system, and adaptive onboarding that tailors guidance to each user's spiritual maturity level.",
+      "Frontier Terminal: AI-native financial intelligence platform and Bloomberg Terminal alternative for retail investors. Built multi-agent backend architecture delivering real-time market data, AI research reports, personalized daily briefings, and multi-channel alert delivery (Telegram, Discord, email, custom webhooks) with conversational AI analyst and persistent portfolio memory.",
     ],
   },
   {


### PR DESCRIPTION
Adds Frontier Terminal to the Projects section as a featured full-width card. Also updates the Frontier Tech Solutions job entry to include FT alongside MacroCrafter and TheWay.

## Changes
- `lib/resume-data.ts` — new project entry + updated FTS job bullet
- `components/sections/projects.tsx` — featured full-width card layout for FT

## Layout
- Row 1: MacroCrafter | TheWay (2-column, existing)
- Row 2: Frontier Terminal (full-width featured card, new FeaturedProjectCard component)