### PR TITLE
feat(portfolio): BytFrontier as flagship build, nest Iris/MacroCrafter/Frontier Terminal under it

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,11 +15,11 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Hugo Cedano | Software Engineer",
-  description: "Software Engineer with expertise in building scalable web applications, leading engineering teams, and delivering high-quality software solutions. Specializing in React, TypeScript, and modern web technologies.",
+  title: "Hugo Cedano | Software Engineer & Founder",
+  description: "Software engineer and founder of Frontier Tech Solutions LLC, building BytFrontier as the flagship user-facing brand for practical AI-native products, agents, and full-stack systems.",
   openGraph: {
-    title: "Hugo Cedano | Software Engineer",
-    description: "Software Engineer with expertise in building scalable web applications, leading engineering teams, and delivering high-quality software solutions.",
+    title: "Hugo Cedano | Software Engineer & Founder",
+    description: "Software engineer and founder of Frontier Tech Solutions LLC, building BytFrontier as the flagship user-facing brand for practical AI-native products.",
     type: "website",
   },
 };

--- a/components/sections/projects.tsx
+++ b/components/sections/projects.tsx
@@ -30,10 +30,10 @@ const itemVariants = {
   },
 } as const;
 
-const signalMetrics = [
-  { label: "Market feed", value: "Realtime" },
-  { label: "Research", value: "AI reports" },
-  { label: "Delivery", value: "Multi-channel" },
+const flagshipSignals = [
+  { label: "LLC shell", value: "Frontier Tech" },
+  { label: "Public brand", value: "BytFrontier" },
+  { label: "Portfolio", value: "3 products" },
 ] as const;
 
 const projectColors = [
@@ -73,23 +73,24 @@ function TechBadge({ tech, index, compact = false }: TechBadgeProps) {
 }
 
 function StatusPill({ project }: { project: Project }) {
-  const isLive = Boolean(project.url);
+  const statusMeta = {
+    live: { label: "Live", color: "var(--neon-green)" },
+    "private-alpha": { label: "Private alpha", color: "var(--neon-electric)" },
+    "in-development": { label: "In development", color: "var(--neon-purple)" },
+  } satisfies Record<Project["status"], { label: string; color: string }>;
+  const meta = statusMeta[project.status];
 
   return (
     <span
       className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[0.66rem] font-bold uppercase tracking-[0.2em]"
       style={{
-        background: isLive
-          ? "color-mix(in oklch, var(--neon-green) 10%, transparent)"
-          : "color-mix(in oklch, var(--neon-purple) 12%, transparent)",
-        borderColor: isLive
-          ? "color-mix(in oklch, var(--neon-green) 42%, transparent)"
-          : "color-mix(in oklch, var(--neon-purple) 42%, transparent)",
-        color: isLive ? "var(--neon-green)" : "var(--neon-purple)",
+        background: `color-mix(in oklch, ${meta.color} 10%, transparent)`,
+        borderColor: `color-mix(in oklch, ${meta.color} 42%, transparent)`,
+        color: meta.color,
       }}
     >
       <span className="size-1.5 rounded-full bg-current shadow-[0_0_10px_currentColor]" />
-      {isLive ? "Live" : "Building"}
+      {meta.label}
     </span>
   );
 }
@@ -119,7 +120,7 @@ function FlagshipProject({ project }: { project: Project }) {
           <div className="mb-5 flex flex-wrap items-center gap-3">
             <StatusPill project={project} />
             <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 font-mono text-[0.66rem] font-bold uppercase tracking-[0.2em] text-white/42">
-              Flagship build
+              {project.category}
             </span>
           </div>
 
@@ -176,13 +177,13 @@ function FlagshipProject({ project }: { project: Project }) {
           <div className="relative z-10 grid h-full content-between gap-4">
             <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-black/38 p-3 backdrop-blur-md">
               <span className="font-mono text-xs uppercase tracking-[0.24em] text-[var(--neon-cyan)]">
-                Intelligence core
+                Brand command
               </span>
-              <span className="font-mono text-xs text-white/34">v1.0</span>
+              <span className="font-mono text-xs text-white/34">LLC</span>
             </div>
 
             <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-              {signalMetrics.map((metric, index) => (
+              {flagshipSignals.map((metric, index) => (
                 <motion.div
                   key={metric.label}
                   className="rounded-2xl border border-white/10 bg-black/42 p-4 backdrop-blur-md"
@@ -225,7 +226,11 @@ function FlagshipProject({ project }: { project: Project }) {
 
 function ProductModule({ project, index }: { project: Project; index: number }) {
   const color = projectColors[index % projectColors.length];
-  const isLive = Boolean(project.url);
+  const statusLabel = {
+    live: "Live",
+    "private-alpha": "Private alpha",
+    "in-development": "In build",
+  } satisfies Record<Project["status"], string>;
 
   const content = (
     <motion.article
@@ -250,10 +255,10 @@ function ProductModule({ project, index }: { project: Project; index: number }) 
               background: `color-mix(in oklch, ${color} 9%, transparent)`,
             }}
           >
-            Product 0{index + 1}
+            {project.category}
           </span>
           <span className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-white/32">
-            {isLive ? "Live" : "In build"}
+            {statusLabel[project.status]}
           </span>
         </div>
 
@@ -303,8 +308,8 @@ function ProductModule({ project, index }: { project: Project; index: number }) 
 function Projects() {
   const sectionRef = React.useRef<HTMLElement>(null);
   const isInView = useInView(sectionRef, { once: true, margin: "-120px" });
-  const flagshipProject = projects.find((project) => project.id === "frontier-terminal");
-  const productModules = projects.filter((project) => project.id !== "frontier-terminal");
+  const flagshipProject = projects.find((project) => project.id === "bytfrontier");
+  const productModules = projects.filter((project) => project.id !== "bytfrontier");
 
   return (
     <section
@@ -337,9 +342,9 @@ function Projects() {
             className="block text-4xl font-black uppercase tracking-[-0.06em] sm:text-5xl md:text-7xl"
           />
           <p className="mt-5 max-w-2xl text-sm leading-7 text-white/58 sm:text-base">
-            Products built as operating systems: commerce, mobile guidance,
-            financial intelligence, agent workflows, realtime delivery, and full
-            production ownership.
+            BytFrontier is the flagship effort: the public brand for Frontier
+            Tech Solutions LLC and the umbrella for Iris, MacroCrafter, and
+            Frontier Terminal. TheWay remains a faith project in development.
           </p>
         </motion.div>
 

--- a/docs/animated-redesign-plan.md
+++ b/docs/animated-redesign-plan.md
@@ -14,7 +14,7 @@
 - Styling is Tailwind CSS 4 plus cyberpunk CSS variables and custom keyframes in `app/globals.css`.
 - Animation runtime is currently `framer-motion` plus CSS keyframes.
 - No Three.js, React Three Fiber, shader, or WebGL dependencies are installed yet.
-- `origin/main` includes the new `Frontier Terminal` featured project and a `bun.lock`, but `package.json` still declares `pnpm@9.15.4`. Use `pnpm` unless we intentionally migrate package managers.
+- `origin/main` has been moving the Projects section toward a product-house hierarchy; use `BytFrontier` as the flagship card, then nest `Iris`, `MacroCrafter`, and `Frontier Terminal` under it. `package.json` declares `pnpm@9.15.4`; use `pnpm` unless we intentionally migrate package managers.
 
 ## Creative Direction
 
@@ -50,8 +50,9 @@ The portfolio content remains real DOM text. Three.js provides the ambient spati
 ### Projects
 
 - Featured project hierarchy:
-  - `Frontier Terminal` as a wide cinematic intelligence-console card.
-  - `MacroCrafter` and `TheWay` as secondary product modules.
+  - `BytFrontier` as the wide flagship card and user-facing brand for Frontier Tech Solutions LLC.
+  - `Iris`, `MacroCrafter`, and `Frontier Terminal` as BytFrontier product modules.
+  - `TheWay` as a separate faith project in development.
 - Cards should have animated scanlines, light sweep, hover tilt, and deep-link affordances.
 - Tech stacks become animated chips or grouped system tags.
 
@@ -193,14 +194,14 @@ Acceptance checks:
 
 ### Phase 4: Project Showcase
 
-- Redesign `Projects` with `Frontier Terminal` as a featured wide card.
+- Redesign `Projects` with `BytFrontier` as the featured wide card and the LLC-centered flagship effort.
 - Add animated product modules and better project hierarchy.
 - Add hover/focus affordances for external links.
 
 Acceptance checks:
 
 - External links are obvious and accessible.
-- `Frontier Terminal` reads as the newest flagship project.
+- `BytFrontier` reads as the flagship build, with Iris, MacroCrafter, and Frontier Terminal clearly nested under it and TheWay marked as a separate faith project.
 - Tech tags do not overwhelm the card copy.
 
 ### Phase 5: Experience And Skills

--- a/lib/resume-data.ts
+++ b/lib/resume-data.ts
@@ -29,6 +29,8 @@ export interface Project {
   id: string;
   name: string;
   url?: string;
+  category: string;
+  status: "live" | "private-alpha" | "in-development";
   description: string;
   techStack: string[];
   featured: boolean;
@@ -69,7 +71,7 @@ export const personalInfo: PersonalInfo = {
 // About / Summary
 // ============================================================================
 
-export const aboutSummary = `Full-stack engineer with 10+ years building web applications across fintech, insurance, and e-commerce. I work across the entire stack—React, Vue, Next.js, Node.js, PostgreSQL, AWS, Supabase—and I've embraced AI-assisted development as a force multiplier. The future of software is agentic, and I'm already there: using AI tools to ship faster, iterate smarter, and focus on solving problems that lead to impact and growth, while worrying less about the noise that sometimes stagnates progress.`;
+export const aboutSummary = `Full-stack engineer and founder of Frontier Tech Solutions LLC, where I'm building BytFrontier as the user-facing flagship brand for practical AI-native products. I work across the entire stack—React, Vue, Next.js, Node.js, PostgreSQL, AWS, Supabase—and use AI-assisted development as a force multiplier to ship faster, iterate smarter, and turn frontier capability into real systems people can use.`;
 
 // ============================================================================
 // Featured Projects
@@ -77,29 +79,46 @@ export const aboutSummary = `Full-stack engineer with 10+ years building web app
 
 export const projects: Project[] = [
   {
-    id: "macrocrafter",
-    name: "MacroCrafter",
-    url: "https://macrocrafter.io",
+    id: "bytfrontier",
+    name: "BytFrontier",
+    url: "https://bytfrontier.com",
+    category: "Flagship build · Frontier Tech Solutions LLC",
+    status: "live",
     description:
-      "AI-powered macro generation SaaS for World of Warcraft and Final Fantasy XIV gaming communities. Full-stack application featuring real-time streaming chat with multiple LLM providers (xAI Grok, OpenAI), three-tier Stripe subscription system with webhook lifecycle management, and secure multi-tenant architecture using Supabase Auth with PostgreSQL Row-Level Security.",
-    techStack: ["Next.js 16", "React 19", "TypeScript", "Supabase (PostgreSQL)", "Redis", "Stripe", "Vercel AI SDK", "Radix UI", "Tailwind CSS", "Playwright", "Jest", "GitHub Actions", "Docker"],
+      "The user-facing flagship brand for Frontier Tech Solutions LLC: a product house and implementation shell for AI-native systems. BytFrontier is the umbrella that houses Iris, MacroCrafter, and Frontier Terminal while keeping the LLC's public story focused around practical AI products, brand trust, and shipped systems.",
+    techStack: ["Next.js 16", "React 19", "TypeScript", "Brand System", "GTM", "AI Agents", "SaaS Ops", "Vercel", "Supabase", "Composio", "Hermes Agent"],
     featured: true,
   },
   {
-    id: "theway",
-    name: "TheWay",
-    url: undefined,
+    id: "iris",
+    name: "Iris",
+    url: "https://iris.bytfrontier.com",
+    category: "BytFrontier product · Personal AI infrastructure",
+    status: "private-alpha",
     description:
-      "AI-powered mobile app guiding users through personalized spiritual journeys with daily devotionals, Orthodox calendar integration, and an intelligent conversational assistant. Features include a full 76-book Orthodox Bible reader with annotations, AI-generated liturgical imagery, gamified progression system, and adaptive onboarding that tailors guidance to each user's spiritual maturity level.",
-    techStack: ["React Native", "Expo Router", "NativeWind", "Legend State", "NestJS", "Supabase (PostgreSQL, Edge Functions, Realtime, Auth)", "Letta AI", "Google Gemini API", "TypeScript"],
+      "Newest BytFrontier product in build: a dedicated AI agent provisioned per user through Telegram, with connected tool access, sovereign per-user state, and practical workflows that move from chat to action without another dashboard.",
+    techStack: ["Hermes Agent", "Telegram", "Composio", "Next.js", "TypeScript", "Supabase", "OAuth", "Agent Memory", "Integrations"],
+    featured: true,
+  },
+  {
+    id: "macrocrafter",
+    name: "MacroCrafter",
+    url: "https://macrocrafter.io",
+    category: "BytFrontier product · Gaming SaaS",
+    status: "live",
+    description:
+      "AI-powered macro generation SaaS for World of Warcraft and Final Fantasy XIV communities. MacroCrafter is the specialist gaming product under BytFrontier, proving niche workflow depth through streaming LLM chat, subscriptions, and secure multi-tenant infrastructure.",
+    techStack: ["Next.js 16", "React 19", "TypeScript", "Supabase (PostgreSQL)", "Redis", "Stripe", "Vercel AI SDK", "Radix UI", "Tailwind CSS", "Playwright", "Jest", "GitHub Actions", "Docker"],
     featured: true,
   },
   {
     id: "frontier-terminal",
     name: "Frontier Terminal",
     url: "https://frontier-terminal.com",
+    category: "BytFrontier product · Market intelligence",
+    status: "live",
     description:
-      "AI-native financial intelligence platform built as a Bloomberg Terminal alternative for retail investors. Features real-time market data, AI-powered research reports, personalized daily briefings, multi-channel alert delivery (Telegram, Discord, email, webhooks), a conversational AI analyst with persistent portfolio memory, and a multi-agent backend architecture for continuous intelligence delivery.",
+      "Market-intelligence product under the BytFrontier umbrella, built for AI-assisted research, personalized briefings, multi-channel alert delivery, and persistent analyst memory. Frontier Terminal remains a strong portfolio proof point, but no longer carries the flagship role alone.",
     techStack: [
       "Next.js 16",
       "React 19",
@@ -112,6 +131,17 @@ export const projects: Project[] = [
       "Fly.io",
       "GitHub Actions",
     ],
+    featured: true,
+  },
+  {
+    id: "theway",
+    name: "TheWay",
+    url: undefined,
+    category: "Faith project · In development",
+    status: "in-development",
+    description:
+      "Faith-centered mobile app in development, separate from the BytFrontier product umbrella. TheWay explores Orthodox Christian spiritual formation through daily guidance, liturgical context, Bible reading, and reflective progression without being positioned as the LLC's flagship commercial build.",
+    techStack: ["React Native", "Expo Router", "NativeWind", "Legend State", "NestJS", "Supabase (PostgreSQL, Edge Functions, Realtime, Auth)", "Letta AI", "Google Gemini API", "TypeScript"],
     featured: true,
   },
 ];
@@ -145,9 +175,12 @@ export const jobs: Job[] = [
     endDate: "Current",
     isCurrent: true,
     description: [
-      "MacroCrafter: AI-powered macro generation SaaS for World of Warcraft and Final Fantasy XIV gaming communities. Full-stack application featuring real-time streaming chat with multiple LLM providers (xAI Grok, OpenAI), three-tier Stripe subscription system with webhook lifecycle management, and secure multi-tenant architecture using Supabase Auth with PostgreSQL Row-Level Security.",
-      "TheWay: AI-powered mobile app guiding users through personalized spiritual journeys with daily devotionals, Orthodox calendar integration, and an intelligent conversational assistant. Features include a full 76-book Orthodox Bible reader with annotations, AI-generated liturgical imagery, gamified progression system, and adaptive onboarding that tailors guidance to each user's spiritual maturity level.",
-      "Frontier Terminal: AI-native financial intelligence platform and Bloomberg Terminal alternative for retail investors. Built multi-agent backend architecture delivering real-time market data, AI research reports, personalized daily briefings, and multi-channel alert delivery (Telegram, Discord, email, custom webhooks) with conversational AI analyst and persistent portfolio memory.",
+      "Founded Frontier Tech Solutions LLC and am developing BytFrontier as the user-facing flagship brand: a product house and implementation shell for AI-native SaaS, agents, automations, and integrations.",
+      "BytFrontier portfolio: Iris as the newest personal AI infrastructure product, MacroCrafter as the gaming workflow SaaS, and Frontier Terminal as the market-intelligence product — distinct products under one coherent LLC story.",
+      "Iris: Telegram-native dedicated AI agent in build, provisioned per user with connected tool access, sovereign state, and workflows that move from chat to action through integrations.",
+      "MacroCrafter: AI-powered macro generation SaaS for World of Warcraft and Final Fantasy XIV communities, with streaming LLM chat, subscriptions, and secure multi-tenant Supabase infrastructure.",
+      "Frontier Terminal: AI-assisted market-intelligence product delivering research context, personalized briefings, multi-channel alerts, and persistent analyst memory.",
+      "TheWay: faith-centered Orthodox Christian mobile app in development, kept as a separate spiritual formation project rather than the flagship LLC commercial brand.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

Reposition the portfolio hierarchy so **BytFrontier** is the flagship user-facing brand/build for **Frontier Tech Solutions LLC**, with products nested under it.

### Changes

- **BytFrontier** → flagship build (user-facing brand for the LLC)
- **Iris** → newest BytFrontier product, personal AI infrastructure (private-alpha)
- **MacroCrafter** → BytFrontier product, gaming SaaS (live)
- **Frontier Terminal** → BytFrontier product, market intelligence (live, no longer flagship)
- **TheWay** → separate faith project in development (not an LLC flagship)

### Files Modified

-  — Added  +  fields to Project type; reframed all projects under BytFrontier umbrella; updated experience bullets and About summary
-  — Flagship card now BytFrontier; subsidiary cards use category + status; updated section intro copy
-  — Metadata updated to "Software Engineer & Founder" with LLC/BytFrontier description
-  — Updated plan references from Frontier Terminal flagship to BytFrontier hierarchy

### Verification

-  ✓
- 
> hugocodes-next@0.1.0 lint /Users/ih.hugh/Development/_Personal/hugocodes-next
> eslint


/Users/ih.hugh/Development/_Personal/hugocodes-next/components/component-example.tsx
  85:9  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

✖ 1 problem (0 errors, 1 warning) ✓ (1 pre-existing warning unrelated)
- 
> hugocodes-next@0.1.0 test /Users/ih.hugh/Development/_Personal/hugocodes-next
> vitest run


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/Users/ih.hugh/Development/_Personal/hugocodes-next[39m

 [32m✓[39m lib/glitch/viewport.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m lib/glitch/scramble.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 3[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m13 passed[39m[22m[90m (13)[39m
[2m   Start at [22m 18:24:07
[2m   Duration [22m 123ms[2m (transform 30ms, setup 0ms, import 46ms, tests 5ms, environment 0ms)[22m ✓ (2 test files, 13 tests)
- 
> hugocodes-next@0.1.0 build /Users/ih.hugh/Development/_Personal/hugocodes-next
> next build

▲ Next.js 16.1.4 (Turbopack)
- Environments: .env.local

  Creating an optimized production build ...
✓ Compiled successfully in 1381.0ms
  Running TypeScript ...
  Collecting page data using 13 workers ...
  Generating static pages using 13 workers (0/4) ...
  Generating static pages using 13 workers (1/4) 
  Generating static pages using 13 workers (2/4) 
  Generating static pages using 13 workers (3/4) 
✓ Generating static pages using 13 workers (4/4) in 169.9ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
└ ○ /_not-found


○  (Static)  prerendered as static content ✓
- Visual dev server preview: flagship card renders correctly with nested product modules